### PR TITLE
⬆️ Bump tlab-analysis from 0.5.1 to 0.5.2 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 dependencies = [
   "dash~=2.16.1",
   "dash-bootstrap-components~=1.5.0",
-  "tlab-analysis @ git+https://github.com/wasedatakeuchilab/tlab-analysis@v0.5.1",
+  "tlab-analysis @ git+https://github.com/wasedatakeuchilab/tlab-analysis@v0.5.2",
   "tlab-pptx @ git+https://github.com/wasedatakeuchilab/tlab-pptx@v0.1.5",
   "asgiref~=3.7.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "dash~=2.16.1",
   "dash-bootstrap-components~=1.5.0",
   "tlab-analysis @ git+https://github.com/wasedatakeuchilab/tlab-analysis@v0.5.2",
-  "tlab-pptx @ git+https://github.com/wasedatakeuchilab/tlab-pptx@v0.1.5",
+  "tlab-pptx @ git+https://github.com/wasedatakeuchilab/tlab-pptx@v0.1.6",
   "asgiref~=3.7.2",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
https://github.com/wasedatakeuchilab/tlab-analysis/releases/tag/v0.5.2