### PR TITLE
⬆️ Bump tlab-analysis and tlab-pptx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ maintainers = [
 dependencies = [
   "dash==2.17.1",
   "dash-bootstrap-components==1.6.0",
-  "tlab-analysis @ git+https://github.com/wasedatakeuchilab/tlab-analysis@v0.5.2",
-  "tlab-pptx @ git+https://github.com/wasedatakeuchilab/tlab-pptx@v0.1.6",
+  "tlab-analysis @ git+https://github.com/wasedatakeuchilab/tlab-analysis@v0.5.3",
+  "tlab-pptx @ git+https://github.com/wasedatakeuchilab/tlab-pptx@v0.1.7",
   "asgiref==3.8.1",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
- https://github.com/wasedatakeuchilab/tlab-analysis/releases/tag/v0.5.3
- https://github.com/wasedatakeuchilab/tlab-pptx/releases/tag/v0.1.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated versions of external dependencies `tlab-analysis` to `v0.5.3` and `tlab-pptx` to `v0.1.7`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->